### PR TITLE
Fix windows problem

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='mcp-sse-proxy',
-    version='0.1.3',
+    version='0.1.4',
     description='Proxy between MCP server using STDIO transport and client using SSE transport',
     author='Artur Zdolinski',
     author_email='artur@zdolinski.com',

--- a/src/mcp_sse_proxy.py
+++ b/src/mcp_sse_proxy.py
@@ -220,7 +220,7 @@ class Proxy:
                                 continue
 
                             logger.debug("Received SSE chunk of size: %d", len(chunk))
-                            buffer += chunk
+                            buffer += chunk.replace("\r\n", "\n")
                             while "\n\n" in buffer:
                                 event, buffer = buffer.split("\n\n", 1)
                                 event_lines = event.strip().split("\n")


### PR DESCRIPTION
Code is looking for the SSE message separator as "\n\n" (two newline characters, LF LF), but the logs indicate that the server uses CRLF as the end-of-line marker.
Fix #1 